### PR TITLE
CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "license": "Apache-2.0",
   "author": "Tal Beja",
-  "license": "ISC",
   "dependencies": {
     "async": "^2.1.4",
     "basic-auth": "^1.1.0",
@@ -32,6 +31,7 @@
     "body-parser": "^1.17.1",
     "cc-get-assets-outputs": "^1.2.0",
     "cc-transaction": "^1.2.0",
+    "cors": "^2.8.3",
     "express": "^4.15.2",
     "iniparser": "^1.0.5",
     "level": "^1.6.0",

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ var auth = require('basic-auth')
 var path = require('path-extra')
 var ospath = require('ospath')
 var socketio = require('socket.io')
+var cors = require('cors')
 
 var propertiesFilePath = path.join(ospath.data(), 'coloredcoins-full-node', 'properties.conf')
 var config = require(path.join(__dirname, '/../utils/config.js'))(propertiesFilePath)
@@ -45,6 +46,7 @@ var launchServer = function (type) {
 }
 
 var app = express()
+app.use(cors())
 app.use(morgan)
 app.use(bodyParser.json())                              // Support for JSON-encoded bodies
 app.use(bodyParser.urlencoded({ extended: true }))      // Support for URL-encoded bodies


### PR DESCRIPTION
Allow browser to connect to full node REST API
(launching from localhost on a different port results in "Origin is not allowed by Access-Control-Allow-Origin ...").