### PR TITLE
getUtxos

### DIFF
--- a/router/router.js
+++ b/router/router.js
@@ -7,6 +7,13 @@ var routes = [
     optionalParams: ['numOfConfirmations']
   },
   {
+    path: '/getUtxos',
+    method: 'post',
+    functionName: 'getUtxos',
+    params: ['utxos'],
+    optionalParams: ['numOfConfirmations']
+  },
+  {
     path: '/getAddressesTransactions',
     method: 'post',
     functionName: 'getAddressesTransactions',


### PR DESCRIPTION
POST /getUtxos
parameters:
 - `utxos` (each consists of `txid` and `index`, required)
 - `numOfConfirmations`

populates a list of 'slim' utxos holding only txid and index pairs - and returns populated utxos objects as returned from bitcoind.