### PR TITLE
remove getprevoutputs from sockets

### DIFF
--- a/src/block_parser.js
+++ b/src/block_parser.js
@@ -592,18 +592,17 @@ module.exports = function (args) {
     bitcoin.cmd('sendrawtransaction', [txHex], function(err, res) {
       if (err) {
         return cb(err)
-      } else {
-        cb(err, '{ "txid": "' +  res + '" }')
       }
       var transaction = decodeRawTransaction(bitcoinjs.Transaction.fromHex(txHex))
       addColoredIOs(transaction, function(err, colored_tx){
-        if (err) return
+        if (err) return cb(null, '{ "txid": "' +  res + '" }')
         getPreviousOutputs(colored_tx, function(err, tx) {
-          if(err) return
+          if(err) return cb(null, '{ "txid": "' +  res + '" }')
           emitter.emit('newtransaction', tx)
           if (tx.colored) {
             emitter.emit('newcctransaction', tx)
           }
+          return cb(null, '{ "txid": "' +  res + '" }')
         })
       })
     })


### PR DESCRIPTION
I was hoping to actually test this with the dashboard first, but I'm waiting for it to finish syncing first, should be done in ~3 hours...

The change here is that I no longer get prevoutputs for sockets, which saves a lot of time while syncing. Instead, when transmitting a transaction, we get its previous outputs and notify the sdk via socket. This means that if some other node which uses the same seed does an outgoing transfer, our node **will not** notify the sdk about it. We decided that it's OK as a trade-off for now. Incoming transactions aren't affected.